### PR TITLE
Allow timeout to be passed in

### DIFF
--- a/RasaNluNetStandard/RasaNluClient.cs
+++ b/RasaNluNetStandard/RasaNluClient.cs
@@ -18,6 +18,12 @@ namespace IronMooseDevelopment.RasaNlu
         {
             BaseDomain = baseDomain;
         }
+        
+        public RasaNluClient(string baseDomain, TimeSpan timeout)
+        {
+            BaseDomain = baseDomain;
+            Client.Timeout = timeout;
+        }
 
         #region Parse
 


### PR DESCRIPTION
Default timeout is 100 seconds. Rasa training often takes much longer than that, so allowing a custom timeout to be passed in will be very helpful.